### PR TITLE
fixed bug regarding unanswered req. questions; made required questions more clear

### DIFF
--- a/survey/survey_views.py
+++ b/survey/survey_views.py
@@ -244,7 +244,7 @@ def response(request, survey_pk, page_num):
         #these_answer_keys = [k for k in request.POST.keys() if str(q.id) == k[:k.index('_')]]
         if q.required and not these_answers:# (set([str(a.id) for a in q.answer_set.all()]).intersection(set([k for k in request.POST.keys() if request.POST.get(k)!='']))): #or request.POST.getlist(str(q.id))==['']):
             highlight_question.append(q.id)
-            if survey.auto_number: errors.append('Question %d requires a response.'%q_log_list[i][2])
+            if survey.auto_number: errors.append('Question %d requires a response.'%q_log_list[i][0].qnumber)
             else: errors=['Questions with an asterisk require a response']
         
         #check formats of answers

--- a/survey/templates/survey/questiondetail.html
+++ b/survey/templates/survey/questiondetail.html
@@ -97,6 +97,9 @@
                     
                     {% if q.id in highlight_question %}<label for="question {{ q.id }}" style="color: red">
                     {% else %} <label for="question {{ q.id }}">{% endif%}
+
+                    {% if q.required %}* {% endif %}
+
                     <i>{{ q.qtext }}</i></label><br />
                     
                     {% for answer, resp in answer_list %}


### PR DESCRIPTION
Addressed bugs pointed out by Marybel in the Online Questionnaires - Bug Notes spreadsheet. 

When I submitted a page with an unanswered required question, surveyviews.py:247 broke reporting that the tuple index was out of bounds.

The offending code: 
`q_log_list[i][2]`

So `q_log_list[i]` seems to return tuple (Question, [Answer, Answer, Answer, ...]) so accessing index 2 didn't make sense. Maybe there's a case where it does but I can't think of any. To fix this I changed the code to:

`q_log_list[i][0].qnumber`

Also, when `Survey.auto_number` is False when this happens the error text reads "Questions with an asterisk require a response" which is confusing since the asterisks aren't there, so at Marybel's suggestion I added an asterisk next to required questions.

![screenshot 2015-07-10 17 06 48](https://cloud.githubusercontent.com/assets/755891/8631397/e99bc122-2729-11e5-9afb-b93560f55373.png)
![screenshot 2015-07-10 17 05 48](https://cloud.githubusercontent.com/assets/755891/8631398/e99cdd46-2729-11e5-91f6-09cb4b916cab.png)
![screenshot 2015-07-10 17 05 23](https://cloud.githubusercontent.com/assets/755891/8631399/e99ce494-2729-11e5-9f2c-3f60009b034d.png)
