### PR TITLE
Basic edit question conditions UI

### DIFF
--- a/survey/templates/survey/edit.html
+++ b/survey/templates/survey/edit.html
@@ -11,6 +11,35 @@
     <script src="https://code.jquery.com/ui/1.10.4/jquery-ui.js"> </script>
 
     <script type="text/javascript">
+        function onCondQuestionChange(target_qid, condition_qid, language_code) {
+            // make the select for both columns the same
+            $("." + target_qid + "_condition_question").val(condition_qid);
+
+            var qid_to_answers = {{qid_to_answers|safe}};
+            var selects = $('.' + target_qid + '_condition_answer');
+
+            selects.empty();
+
+            selects.append(
+                $("<option></option>")
+                .attr("value", "ANY")
+                .text("ANY")
+            );
+
+            $.each(qid_to_answers[condition_qid], function (i, answer) {
+                selects.append(
+                    $("<option></option>")
+                    .attr("value", answer["id"])
+                    .text(answer["atext_" + language_code])
+                );
+            });
+        }
+
+        function onCondAnswerChange(target_qid, condition_aid) {
+            // make the select for both columns the same
+            $("." + target_qid + "_condition_answer").val(condition_aid);
+        }
+
         function highlight(id) {
             var elements = document.getElementsByClassName(id);
             for (var i = 0; i < elements.length; ++i) {

--- a/survey/templates/survey/partials/editsurvey.html
+++ b/survey/templates/survey/partials/editsurvey.html
@@ -2,6 +2,58 @@
 {% language language_code %}
 {% for q, answer_list in q_log_list %}
 
+<!-- Question conditions -->
+<div id="column1">
+<p style="margin-top: 0px; margin-bottom: 0px;">Conditions</p>
+
+<!-- Existing conditions with delete button -->
+{% for cond_a in q.condition_answers.all %}
+    {{ cond_a }}
+    <button type="submit" 
+        name="action" 
+        value="del_cond_answer_{{ cond_a.id }}_for_Question_{{ q.id }}">
+        {% trans "Delete" %}
+    </button>
+    <br>
+{% endfor %}
+
+{% for cond_q in q.condition_questions.all %}
+    {{ cond_q }}
+    <button type="submit" 
+        name="action" 
+        value="del_cond_question_{{ cond_q.id }}_for_Question_{{ q.id }}">
+        {% trans "Delete" %}
+    </button>
+    <br>
+    {% endfor %}
+</div>
+
+<div id="column2">
+    <!-- condition_question select element -->
+    <select style="max-width: 40%;" 
+        name="Question_{{ q.id }}_condition_question" 
+        onchange="onCondQuestionChange({{ q.id }}, this.value, &quot;{{ language_code }}&quot;);" 
+        class="{{ q.id }}_condition_question">
+        {% for all_q in all_questions %}
+            <option value="{{ all_q.id }}">
+              {{ all_q.qtext }}
+            </option>
+        {% endfor %}
+    </select>
+
+    <!-- condiiton_answer select element -->
+    <select style="max-width: 40%;" 
+        name="Question_{{ q.id }}_condition_answer" 
+        onchange="onCondAnswerChange({{ q.id }}, this.value);" 
+        class="{{ q.id }}_condition_answer">
+    </select>
+
+    <!-- Submit button for adding this condition -->
+    <button type="submit" name="action" value="add_cond_to_Question_{{ q.id }}">{% trans "Add" %}</button>
+</div>
+
+
+<!-- Question text and answer text -->
 <question id="{{ q.id }}">
     <input type="text" 
         name="Question_{{ q.id }}_qtext_{{ language_code }}"


### PR DESCRIPTION
- fixed bug I introduced in a previous commit (survey_views.py:461)
- implemented a bad but working edit conditions interface in survey editor. it got messy since I can't put a form in a form and everything is already in one big form to make it possible to edit question/answer text. so even though it makes sense to make the delete condition and add condition actions each their own form I couldn't figure out how so I hacked around it by putting information in the submit button's value.
